### PR TITLE
Fixed NaN output when masking full head

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6449,7 +6449,10 @@ def multi_head_attention_forward(
             )
         else:
             attn_output_weights = torch.bmm(q_scaled, k.transpose(-2, -1))
+
         attn_output_weights = softmax(attn_output_weights, dim=-1)
+        attn_output_weights = torch.nan_to_num(attn_output_weights, nan=0.0)
+
         if dropout_p > 0.0:
             attn_output_weights = dropout(attn_output_weights, p=dropout_p)
 
@@ -6470,6 +6473,7 @@ def multi_head_attention_forward(
             # squeeze the output if input was unbatched
             attn_output = attn_output.squeeze(1)
             attn_output_weights = attn_output_weights.squeeze(0)
+
         return attn_output, attn_output_weights
     else:
         # attn_mask can be either (L,S) or (N*num_heads, L, S)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6459,8 +6459,12 @@ def multi_head_attention_forward(
         # safe softmax
         attn_output_weights = softmax(attn_output_weights, dim=-1)
         all_neginf_along_dim = is_neginf.all(dim=-1, keepdim=True)
-        zeros = torch.scalar_tensor(0.0, dtype=attn_output_weights.dtype, device=attn_output_weights.device)
-        attn_output_weights = torch.where(all_neginf_along_dim, zeros, attn_output_weights)
+        zeros = torch.scalar_tensor(
+            0.0, dtype=attn_output_weights.dtype, device=attn_output_weights.device
+        )
+        attn_output_weights = torch.where(
+            all_neginf_along_dim, zeros, attn_output_weights
+        )
 
         if dropout_p > 0.0:
             attn_output_weights = dropout(attn_output_weights, p=dropout_p)


### PR DESCRIPTION
Fixes #160064

Fixing reported issue when fully masking a head. Functionality was tested with the provided code and ran successfully through multi-head attention tests. Safe softmax is now applied based on the [C++ implementation](https://github.com/pytorch/pytorch/blob/38d65c64658928929a5c70114b56041096aaf0dd/aten/src/ATen/native/transformers/attention.cpp#L678). Current Implementation returns `0.0` unless all heads are masked. Multihead attetion tests run successfully but I am not sure if they cover the weights (unless values can safely be either `NaN` and `0.0`). 

In order to successfully pass the multi-head attention tests, I had to conditionally remove the safe softmax in order to return full `NaN` output. 

```python
import torch
from torch import nn

# set random seed for reproducibility

torch.manual_seed(0)

x = torch.randn(
    1,
    5,
    3,
)
mask = torch.tensor([False, False, True]).view(-1, 1, 1).expand(-1, 5, 5)
att = nn.MultiheadAttention(3, 3, batch_first=True)
y1, _ = att(x, x, x, attn_mask=mask, average_attn_weights=False, need_weights=False)
y2, weights = att(
    x, x, x, attn_mask=mask, average_attn_weights=False, need_weights=True
)

print("\nWithout weights:")
print("================")
print(y1)


print("\nWith weights:")
print("==============")
print(y2)
print("weights:")
print("---------")
print(weights)
```

Output with fix

```
Without weights:
================
tensor([[[ 0.1826,  0.2504, -0.1536],
         [ 0.2397,  0.3338, -0.1909],
         [ 0.2016,  0.2827, -0.1566],
         [ 0.2573,  0.3627, -0.1960],
         [ 0.2061,  0.2918, -0.1541]]], grad_fn=<TransposeBackward0>)

With weights:
==============
tensor([[[ 0.1826,  0.2504, -0.1536],
         [ 0.2397,  0.3338, -0.1909],
         [ 0.2016,  0.2827, -0.1566],
         [ 0.2573,  0.3627, -0.1960],
         [ 0.2061,  0.2918, -0.1541]]], grad_fn=<TransposeBackward0>)
weights:
---------
tensor([[[[0.0631, 0.2339, 0.0849, 0.5519, 0.0662],
          [0.1515, 0.2287, 0.1664, 0.2995, 0.1539],
          [0.1234, 0.2388, 0.1434, 0.3680, 0.1265],
          [0.2448, 0.1641, 0.2236, 0.1262, 0.2413],
          [0.1587, 0.2253, 0.1719, 0.2833, 0.1608]],

         [[0.3441, 0.3239, 0.1070, 0.1290, 0.0960],
          [0.3130, 0.2987, 0.1262, 0.1460, 0.1160],
          [0.1865, 0.1876, 0.2092, 0.2053, 0.2114],
          [0.2027, 0.2025, 0.1982, 0.1989, 0.1978],
          [0.0993, 0.1046, 0.2700, 0.2299, 0.2961]],

         [[0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000]]]], grad_fn=<ViewBackward0>)
```